### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/webpack.yml
+++ b/.github/workflows/webpack.yml
@@ -6,6 +6,9 @@ on:
     pull_request:
         branches: ['main']
 
+permissions:
+    contents: read
+
 jobs:
     build:
         runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/wangdianwen/apollo-server-initial-project/security/code-scanning/1](https://github.com/wangdianwen/apollo-server-initial-project/security/code-scanning/1)

In general, the fix is to explicitly declare the minimal `permissions` needed for the `GITHUB_TOKEN` in this workflow. Since the shown steps only need to read repository contents (for checkout) and then run local commands (`yarn` scripts), the minimal safe permission is `contents: read`.

The best way to fix this without changing behavior is to add a `permissions` block at the top workflow level, so it applies to all jobs (here, just `build`). This means editing `.github/workflows/webpack.yml` to insert:

```yaml
permissions:
    contents: read
```

between the `on:` block and the `jobs:` block. No imports, additional methods, or structural changes are needed; we only add this YAML key.

Concretely: in `.github/workflows/webpack.yml`, after line 7 (`branches: ['main']`) and before line 9 (`jobs:`), insert the `permissions` section with `contents: read` as shown in the replacement block below.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
